### PR TITLE
Allow opt-out of building with gopacket

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -1,3 +1,5 @@
+//go:build !ja3_disable_gopacket
+
 /*
  * JA3 - TLS Client Hello Hash
  * Copyright (c) 2017, Salesforce.com, Inc.

--- a/gopacket.go
+++ b/gopacket.go
@@ -1,3 +1,5 @@
+//go:build !ja3_disable_gopacket
+
 /*
  * JA3 - TLS Client Hello Hash
  * Copyright (c) 2017, Salesforce.com, Inc.

--- a/ja3s.go
+++ b/ja3s.go
@@ -17,81 +17,10 @@ package ja3
 import (
 	"crypto/md5"
 	"encoding/hex"
-	"fmt"
-	"io"
 	"strconv"
-	"strings"
 
 	"github.com/dreadl0ck/tlsx"
-	"github.com/google/gopacket"
 )
-
-// ReadFileJa3s reads the PCAP file at the given path
-// and prints out all packets containing JA3S digests to the supplied io.Writer
-func ReadFileJa3s(file string, out io.Writer) {
-
-	r, f, link, err := openPcap(file)
-	if err != nil {
-		panic(err)
-	}
-	defer f.Close()
-
-	count := 0
-	for {
-		// read packet data
-		data, _, err := r.ReadPacketData()
-		if err == io.EOF {
-			if Debug {
-				fmt.Println(count, "fingerprints.")
-			}
-			return
-		} else if err != nil {
-			panic(err)
-		}
-
-		var (
-			// create gopacket
-			p = gopacket.NewPacket(data, link, gopacket.Lazy)
-			// get JA3 if possible
-			digest = DigestHexPacketJa3s(p)
-		)
-
-		// check if we got a result
-		if digest != "" {
-
-			count++
-
-			var (
-				b  strings.Builder
-				nl = p.NetworkLayer()
-				tl = p.TransportLayer()
-			)
-
-			// got an a digest but no transport or network layer
-			if tl == nil || nl == nil {
-				if Debug {
-					fmt.Println("got a nil layer: ", nl, tl, p.Dump(), digest)
-				}
-				continue
-			}
-
-			b.WriteString("[")
-			b.WriteString(nl.NetworkFlow().Dst().String())
-			b.WriteString(":")
-			b.WriteString(tl.TransportFlow().Dst().String())
-			b.WriteString("] JA3S: ")
-			b.WriteString(string(BarePacketJa3s(p)))
-			b.WriteString(" --> ")
-			b.WriteString(digest)
-			b.WriteString("\n")
-
-			_, err := out.Write([]byte(b.String()))
-			if err != nil {
-				panic(err)
-			}
-		}
-	}
-}
 
 // BareToDigestHex converts a bare []byte to a hex string.
 func BareToDigestHexJa3s(bare []byte) string {

--- a/ja3s_pcap.go
+++ b/ja3s_pcap.go
@@ -1,0 +1,78 @@
+//go:build !ja3_disable_gopacket
+
+package ja3
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/google/gopacket"
+)
+
+// ReadFileJa3s reads the PCAP file at the given path
+// and prints out all packets containing JA3S digests to the supplied io.Writer
+func ReadFileJa3s(file string, out io.Writer) {
+
+	r, f, link, err := openPcap(file)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	count := 0
+	for {
+		// read packet data
+		data, _, err := r.ReadPacketData()
+		if err == io.EOF {
+			if Debug {
+				fmt.Println(count, "fingerprints.")
+			}
+			return
+		} else if err != nil {
+			panic(err)
+		}
+
+		var (
+			// create gopacket
+			p = gopacket.NewPacket(data, link, gopacket.Lazy)
+			// get JA3 if possible
+			digest = DigestHexPacketJa3s(p)
+		)
+
+		// check if we got a result
+		if digest != "" {
+
+			count++
+
+			var (
+				b  strings.Builder
+				nl = p.NetworkLayer()
+				tl = p.TransportLayer()
+			)
+
+			// got an a digest but no transport or network layer
+			if tl == nil || nl == nil {
+				if Debug {
+					fmt.Println("got a nil layer: ", nl, tl, p.Dump(), digest)
+				}
+				continue
+			}
+
+			b.WriteString("[")
+			b.WriteString(nl.NetworkFlow().Dst().String())
+			b.WriteString(":")
+			b.WriteString(tl.TransportFlow().Dst().String())
+			b.WriteString("] JA3S: ")
+			b.WriteString(string(BarePacketJa3s(p)))
+			b.WriteString(" --> ")
+			b.WriteString(digest)
+			b.WriteString("\n")
+
+			_, err := out.Write([]byte(b.String()))
+			if err != nil {
+				panic(err)
+			}
+		}
+	}
+}

--- a/json.go
+++ b/json.go
@@ -1,3 +1,5 @@
+//go:build !ja3_disable_gopacket
+
 /*
  * JA3 - TLS Client Hello Hash
  * Copyright (c) 2017, Salesforce.com, Inc.

--- a/live.go
+++ b/live.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"github.com/google/gopacket/pcapgo"
 	"io"
 	"os"
 	"strings"
@@ -15,6 +14,7 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"
+	"github.com/google/gopacket/pcapgo"
 )
 
 // ReadInterface reads packets from the named interface

--- a/live.go
+++ b/live.go
@@ -1,3 +1,5 @@
+//go:build !ja3_disable_gopacket
+
 package ja3
 
 import (

--- a/utils.go
+++ b/utils.go
@@ -4,10 +4,10 @@ package ja3
 
 import (
 	"fmt"
-	"github.com/google/gopacket/layers"
 	"os"
 
 	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcapgo"
 )
 

--- a/utils.go
+++ b/utils.go
@@ -1,3 +1,5 @@
+//go:build !ja3_disable_gopacket
+
 package ja3
 
 import (


### PR DESCRIPTION
Provides a way to disable any compilation against `gopacket` which uses CGO which might not be wanted for a project.

Tested this using:

```
go build -tags ja3_disable_gopacket
```